### PR TITLE
Refactoring of feature normalization

### DIFF
--- a/mlclass-ex1/featureNormalize.m
+++ b/mlclass-ex1/featureNormalize.m
@@ -26,16 +26,10 @@ sigma = zeros(1, size(X, 2));
 % Hint: You might find the 'mean' and 'std' functions useful.
 %       
 
-mu    = mean(X)
-sigma = std(X)
+mu    = mean(X);
+sigma = std(X);
 
-indicies = 1:size(X, 2);
-
-for i = indicies,
-  XminusMu  = X(:, i) - mu(i);
-  X_norm(:, i) = XminusMu / sigma(i);
-end
-
+X_norm = (X - mu) ./ sigma;
 
 % ============================================================
 


### PR DESCRIPTION
Octave support the `-` for per-element subtraction and `./` for per-element division. This code seems prettier
